### PR TITLE
Fix schema.json memory pressure

### DIFF
--- a/src/loader.ts
+++ b/src/loader.ts
@@ -40,6 +40,16 @@ async function readFile(
   return content.toString();
 }
 
+async function stat(
+  loader: loader.LoaderContext,
+  filePath: string,
+): Promise<Stats> {
+  const fsStat: (path: string) => Promise<Stats> = pify(
+    loader.fs.stat.bind(loader.fs),
+  );
+  return fsStat(filePath);
+}
+
 async function extractImports(
   loader: loader.LoaderContext,
   resolveContext: string,
@@ -165,14 +175,11 @@ async function findFileInTree(
   context: string,
   schemaPath: string,
 ) {
-  const fsStat: (path: string) => Promise<Stats> = pify(
-    loader.fs.stat.bind(loader.fs),
-  );
   let currentContext = context;
   while (true) {
     const fileName = join(currentContext, schemaPath);
     try {
-      if ((await fsStat(fileName)).isFile()) {
+      if ((await stat(loader, fileName)).isFile()) {
         return fileName;
       }
     } catch (err) {}


### PR DESCRIPTION
This PR fixes an issue where the loader attempts to parse `schema.json` too frequently for a single webpack compilation. the issue occurs because we call `JSON.parse()` on the file contents for every invocation of the loader. Instead, this PR caches `schema.json` and uses the file `mtime` to invalidate what is in the cache.

I tested that this works by aggressively modifying `schema.json` in a project that used to cause OOM death, that works fine after this PR.